### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code-qa.yml
+++ b/.github/workflows/code-qa.yml
@@ -6,6 +6,8 @@ on:
     pull_request:
         branches: [master]
 
+permissions:
+    contents: read
 jobs:
     build:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/AlexJSully/Publication-Figure-Retrieval/security/code-scanning/10](https://github.com/AlexJSully/Publication-Figure-Retrieval/security/code-scanning/10)

To fix this issue, add a `permissions` block with the minimum necessary privilege. For this workflow/job, only read access to repository contents is needed, as all steps are local or read. This can be done by inserting a `permissions:` block either at the root (applies to all jobs) or inside the `build` job. The recommended minimal explicit permission is:
```yaml
permissions:
  contents: read
```
Edit the `.github/workflows/code-qa.yml` file by placing this block just above the `jobs:` key. No further changes are needed unless later jobs/actions require more permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
